### PR TITLE
deps: add mujoco-python-viewer to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires-python = ">=3.8"
 dependencies = [
   "mujoco>=2.3.5,<3.0.0",
   "dm-control",
+  "mujoco-python-viewer",
   "numpy",
   "absl-py",
   "dm-env",


### PR DESCRIPTION
I needed to install `mujoco-python-viewer` this to be able to run:

```python
import mujoco_viewer
```